### PR TITLE
Fixed: oncanplaythrough fails to trigger

### DIFF
--- a/nodekit-browser/src/asset-manager/asset-manager.ts
+++ b/nodekit-browser/src/asset-manager/asset-manager.ts
@@ -18,6 +18,8 @@ export class AssetManager {
     async loadVideoAsset(videoLink: VideoLink): Promise<HTMLVideoElement> {
         // Preload the video asset and return the HTMLVideoElement.
         let element = document.createElement("video");
+        // Disable all video controls.
+        element.controls = false;
         // Subscribe to events prior to assign the source URL to prevent events from triggering prior to assignment:
         let promise: Promise<HTMLVideoElement> = new Promise((resolve, reject) => {
             element.oncanplaythrough = () => {

--- a/nodekit-browser/src/board-view/card-views/video/video-card.ts
+++ b/nodekit-browser/src/board-view/card-views/video/video-card.ts
@@ -68,8 +68,6 @@ export class VideoCardView extends CardView implements ClickableCardView {
         });
         // Start playing the video now.
         this.video.autoplay = true;
-        // Disable all video controls.
-        this.video.controls = false;
         await Promise.race([playing, timeout]);
     }
 }


### PR DESCRIPTION

This PR *might* fix #19 , but we're keeping that Issue open because I can't reproduce a related bug. This PR *definitely* fixes a *related* that I've been able to reproduce.

The related bug: Sometimes `element.oncanplaythrough` is never triggered, causing the video to never play. Fixed in `AssetManager`:

- The Promise that subscribes to `element.oncanplaythrough` is created, and *then* the `element.src` is set. This helps ensure that the event won't trigger before the subscription is set.
- Call `element.load()` to reset the element to its initial state, further ensuring that `element.oncanplaythrough` is triggered.

The *possible* bug fix, in `VideoCard`:

- The two Promises that attempt to check whether the video is playing are defined prior to setting `this.video.autoplay = true;` This *possibly* ensures that the `this.video.onplaying` is subscribed to prior to the video play staring.