### PR TITLE
Add `AssetUrl` to public API

### DIFF
--- a/nodekit/assets/__init__.py
+++ b/nodekit/assets/__init__.py
@@ -1,10 +1,10 @@
 __all__ = [
     'ImageIdentifier',
     'VideoIdentifier',
-    #'AssetIdentifier',
     'AssetFile',
     'ImageFile',
     'VideoFile',
+    'AssetUrl',
 ]
 
 from nodekit._internal.types.assets import (
@@ -13,4 +13,5 @@ from nodekit._internal.types.assets import (
     AssetFile,
     ImageFile,
     VideoFile,
+    AssetUrl,
 )


### PR DESCRIPTION
As `AssetUrl` is expected by the `NodeKit.play` function in `nodekit-browser`, `AssetUrl` has been added to the public API.