### PR TITLE
Improving the time complexity of `nk.concat`

### DIFF
--- a/nodekit/_internal/ops/concat.py
+++ b/nodekit/_internal/ops/concat.py
@@ -32,7 +32,7 @@ def concat(
 
     if len(set(ids)) != len(ids):
         raise ValueError("If ids are given, they must be unique.")
-    
+
     # Validate sequence items:
     if any(not isinstance(x, (Node, Graph)) for x in sequence):
         raise TypeError("All elements in sequence must be `Node` or `Graph`.")
@@ -48,9 +48,7 @@ def concat(
             nodes[current_node_id] = child
 
             # Add connection with NodeId and SensorId pair for the node:
-            connections.append([
-                (current_node_id, sensor) for sensor in child.sensors
-            ])
+            connections.append([(current_node_id, sensor) for sensor in child.sensors])
 
         elif isinstance(child, Graph):
             # Register nodes with namespaced ids:
@@ -85,11 +83,12 @@ def concat(
         from_list = connections[i]
 
         # Get next node id:
-        if isinstance(sequence[i + 1], Node):
+        next_element = sequence[i + 1]
+        if isinstance(next_element, Node):
             to_node = ids[i + 1]
 
-        if isinstance(sequence[i + 1], Graph):
-            to_node = f"{ids[i + 1]}/{sequence[i + 1].start}"
+        if isinstance(next_element, Graph):
+            to_node = f"{ids[i + 1]}/{next_element.start}"
 
         # From connections create transitions to next node:
         for from_id, sensor_id in from_list:

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -1,6 +1,7 @@
 import pytest
 import nodekit as nk
 
+
 # %% Helper functions
 def get_fixation_node() -> nk.Node:
     click_sensor = nk.sensors.ClickSensor(
@@ -48,7 +49,6 @@ def get_negative_node():
     )
 
 
-
 def test_example_pass():
     # Example 1:
     # Visual structure:
@@ -74,7 +74,6 @@ def test_example_pass():
     nodes["negative_1"] = get_negative_node()
     nodes["positive_1"] = get_positive_node()
 
-
     transitions = {}
     transitions["response_1"] = {
         "left": "positive_1" if correct[0] == "left" else "negative_1",
@@ -82,20 +81,18 @@ def test_example_pass():
     }
 
     response = nk.Graph(
-        nodes=nodes, start="response_1", 
+        nodes=nodes,
+        start="response_1",
         transitions=transitions,
-        )
+    )
 
     fix_1 = get_fixation_node()
     stim_1 = get_stimulus_node()
     fix_2 = get_fixation_node()
     stim_2 = get_stimulus_node()
 
-    ids = ['fixation_1', 'stimulus_1', 'trial_1', 'fixation_2', 'stimulus_2']
-    graph = nk.concat(
-        [fix_1, stim_1, response, fix_2, stim_2],
-        ids=ids
-        )
+    ids = ["fixation_1", "stimulus_1", "trial_1", "fixation_2", "stimulus_2"]
+    graph = nk.concat([fix_1, stim_1, response, fix_2, stim_2], ids=ids)
 
     # Check basic Graph properties:
     assert isinstance(graph, nk.Graph)
@@ -123,9 +120,7 @@ def test_example_pass():
                 outgoing = set(graph.transitions.get(node_id, {}).keys())
 
                 missing = sensors - outgoing
-                assert not missing, (
-                    f"Node {node_id} has unconnected sensors: {missing}"
-                )
+                assert not missing, f"Node {node_id} has unconnected sensors: {missing}"
 
 
 def test_concat_invalid_element():
@@ -134,7 +129,7 @@ def test_concat_invalid_element():
     bad_item = "not_a_graph"
 
     with pytest.raises(TypeError, match="must be `Node` or `Graph`"):
-        nk.concat([fix, stim, bad_item])
+        nk.concat([fix, stim, bad_item])  # type: ignore[arg-type]
 
 
 def test_concat_duplicate_ids():
@@ -149,7 +144,9 @@ def test_concat_preserves_internal_edges():
     node_a = nk.Node(cards={}, sensors={"x": nk.sensors.TimeoutSensor(timeout_msec=1)})
     node_b = nk.Node(cards={}, sensors={"y": nk.sensors.TimeoutSensor(timeout_msec=1)})
 
-    g = nk.Graph(nodes={"A": node_a, "B": node_b}, start="A", transitions={"A": {"x": "B"}})
+    g = nk.Graph(
+        nodes={"A": node_a, "B": node_b}, start="A", transitions={"A": {"x": "B"}}
+    )
 
     extra = nk.Node(cards={}, sensors={"z": nk.sensors.TimeoutSensor(timeout_msec=1)})
 


### PR DESCRIPTION
Currently `nk.concat` has a time complexity of O(N^2) due to the transitions between elements in `sequence` having nested iteration. 

This PR will change this behavior and create transitions in O(N) time by registering the start and terminal nodes for each element in sequence and making the transitions outside the original loop.