### PR TITLE
Inlining graph to Trace

### DIFF
--- a/docs/docs/guides/saving-and-sharing.md
+++ b/docs/docs/guides/saving-and-sharing.md
@@ -44,6 +44,9 @@ graph = nk.load_graph("my-task.nkg")
 - You have a path where you want to save the JSON Trace.
 - If you plan to load a Trace, you have the JSON file on disk.
 
+???+ tip "Traces are self-describing"
+    A Trace stores the canonical Graph that was run plus the ordered Events observed while running it. That means a saved Trace JSON file is enough to inspect both the task structure and the behavioral record later.
+
 ## 3. Save a Trace to JSON
 
 Traces are Pydantic models, so you can serialize them with `model_dump_json`:

--- a/docs/docs/reference/values.md
+++ b/docs/docs/reference/values.md
@@ -15,6 +15,7 @@
 ::: nodekit.values.MediaType
 ::: nodekit.values.NodeId
 ::: nodekit.values.NodeAddress
+::: nodekit.values.GraphAddress
 ::: nodekit.values.RegisterId
 
 ::: nodekit.Region

--- a/nodekit-browser/src/event-array.ts
+++ b/nodekit-browser/src/event-array.ts
@@ -1,4 +1,4 @@
-import type {Event} from "./types/events";
+import type {Event, UnindexedEvent} from "./types/events";
 
 export class EventArray {
     public events: Event[];
@@ -11,8 +11,12 @@ export class EventArray {
         this.events = [];
     }
 
-    push(event: Event) {
-        this.events.push(event);
-        this.onEventCallback(event);
+    push(event: UnindexedEvent) {
+        const indexedEvent = {
+            ...event,
+            event_index: this.events.length,
+        } as Event;
+        this.events.push(indexedEvent);
+        this.onEventCallback(indexedEvent);
     }
 }

--- a/nodekit-browser/src/event-array.ts
+++ b/nodekit-browser/src/event-array.ts
@@ -1,4 +1,4 @@
-import type {Event, UnindexedEvent} from "./types/events";
+import type {Event} from "./types/events";
 
 export class EventArray {
     public events: Event[];
@@ -11,12 +11,8 @@ export class EventArray {
         this.events = [];
     }
 
-    push(event: UnindexedEvent) {
-        const indexedEvent = {
-            ...event,
-            event_index: this.events.length,
-        } as Event;
-        this.events.push(indexedEvent);
-        this.onEventCallback(indexedEvent);
+    push(event: Event) {
+        this.events.push(event);
+        this.onEventCallback(event);
     }
 }

--- a/nodekit-browser/src/main.ts
+++ b/nodekit-browser/src/main.ts
@@ -1,6 +1,11 @@
 import type {
     Event,
-    UnindexedEvent,
+    GraphEndedEvent,
+    GraphStartedEvent,
+    PageResumedEvent,
+    PageSuspendedEvent,
+    TraceEndedEvent,
+    TraceStartedEvent,
 } from "./types/events";
 import {Clock} from "./clock.ts";
 import type {Graph, Trace} from "./types/node.ts";
@@ -82,7 +87,7 @@ export async function play(
             await shellUI.playStartScreen()
         }
 
-        const startEvent: UnindexedEvent = {
+        const startEvent: TraceStartedEvent = {
             event_type: "TraceStartedEvent",
             t: 0 as TimeElapsedMsec,
         }
@@ -92,14 +97,14 @@ export async function play(
         function onVisibilityChange() {
             if (document.visibilityState === "hidden") {
                 // Triggered when the document becomes hidden (e.g., user switches tabs or minimizes the window)
-                const leaveEvent: UnindexedEvent = {
+                const leaveEvent: PageSuspendedEvent = {
                     event_type: "PageSuspendedEvent",
                     t: clock.now(),
                 };
                 eventArray.push(leaveEvent);
             } else if (document.visibilityState === "visible") {
                 // Triggered when the document becomes visible again
-                const returnEvent: UnindexedEvent = {
+                const returnEvent: PageResumedEvent = {
                     event_type: "PageResumedEvent",
                     t: clock.now(),
                 };
@@ -126,7 +131,7 @@ export async function play(
         )
 
         // Generate the EndEvent:
-        const endEvent: UnindexedEvent = {
+        const endEvent: TraceEndedEvent = {
             event_type: "TraceEndedEvent",
             t: clock.now(),
         }
@@ -195,7 +200,7 @@ async function playGraph(
     context: PlayGraphContext,
 ): Promise<RegisterFile> {
 
-    const graphStartEvent: UnindexedEvent = {
+    const graphStartEvent: GraphStartedEvent = {
         event_type: "GraphStartedEvent",
         t: context.clock.now(),
         graph_address: parentAddress,
@@ -282,7 +287,7 @@ async function playGraph(
         lastAction = null;
     }
 
-    const graphEndEvent: UnindexedEvent = {
+    const graphEndEvent: GraphEndedEvent = {
         event_type: "GraphEndedEvent",
         t: context.clock.now(),
         graph_address: parentAddress,

--- a/nodekit-browser/src/main.ts
+++ b/nodekit-browser/src/main.ts
@@ -1,11 +1,6 @@
 import type {
     Event,
-    GraphEndedEvent,
-    GraphStartedEvent,
-    PageResumedEvent,
-    PageSuspendedEvent,
-    TraceEndedEvent,
-    TraceStartedEvent,
+    UnindexedEvent,
 } from "./types/events";
 import {Clock} from "./clock.ts";
 import type {Graph, Trace} from "./types/node.ts";
@@ -87,7 +82,7 @@ export async function play(
             await shellUI.playStartScreen()
         }
 
-        const startEvent: TraceStartedEvent = {
+        const startEvent: UnindexedEvent = {
             event_type: "TraceStartedEvent",
             t: 0 as TimeElapsedMsec,
         }
@@ -97,14 +92,14 @@ export async function play(
         function onVisibilityChange() {
             if (document.visibilityState === "hidden") {
                 // Triggered when the document becomes hidden (e.g., user switches tabs or minimizes the window)
-                const leaveEvent: PageSuspendedEvent = {
+                const leaveEvent: UnindexedEvent = {
                     event_type: "PageSuspendedEvent",
                     t: clock.now(),
                 };
                 eventArray.push(leaveEvent);
             } else if (document.visibilityState === "visible") {
                 // Triggered when the document becomes visible again
-                const returnEvent: PageResumedEvent = {
+                const returnEvent: UnindexedEvent = {
                     event_type: "PageResumedEvent",
                     t: clock.now(),
                 };
@@ -131,7 +126,7 @@ export async function play(
         )
 
         // Generate the EndEvent:
-        const endEvent: TraceEndedEvent = {
+        const endEvent: UnindexedEvent = {
             event_type: "TraceEndedEvent",
             t: clock.now(),
         }
@@ -143,6 +138,7 @@ export async function play(
         // Assemble trace:
         const trace: Trace = {
             nodekit_version: NODEKIT_VERSION,
+            graph: graph,
             events: eventArray.events,
         }
 
@@ -199,11 +195,10 @@ async function playGraph(
     context: PlayGraphContext,
 ): Promise<RegisterFile> {
 
-    const graphStartEvent: GraphStartedEvent = {
+    const graphStartEvent: UnindexedEvent = {
         event_type: "GraphStartedEvent",
         t: context.clock.now(),
         graph_address: parentAddress,
-        annotation: graph.annotation ?? null,
     }
     context.eventArray.push(graphStartEvent);
 
@@ -287,11 +282,10 @@ async function playGraph(
         lastAction = null;
     }
 
-    const graphEndEvent: GraphEndedEvent = {
+    const graphEndEvent: UnindexedEvent = {
         event_type: "GraphEndedEvent",
         t: context.clock.now(),
         graph_address: parentAddress,
-        annotation: graph.annotation ?? null,
     }
     context.eventArray.push(graphEndEvent);
 

--- a/nodekit-browser/src/node-play/index.ts
+++ b/nodekit-browser/src/node-play/index.ts
@@ -9,7 +9,7 @@ import type {Clock} from "../clock.ts";
 import {Deferred} from "../utils.ts";
 import type {NodeAddress} from "../types/values.ts";
 import type {EventArray} from "../event-array.ts";
-import type {ActionTakenEvent, KeySampledEvent, NodeEndedEvent, NodeStartedEvent, PointerSampledEvent} from "../types/events";
+import type {UnindexedEvent} from "../types/events";
 
 
 export class NodePlay {
@@ -47,7 +47,7 @@ export class NodePlay {
         // Have the input streams push to the event stream: todo despaghetti
         const unsubscribePointer = this.boardView.pointerStream.subscribe(
             (pointerSample) => {
-                const e: PointerSampledEvent = {
+                const e: UnindexedEvent = {
                     event_type: 'PointerSampledEvent',
                     t: pointerSample.t,
                     x: pointerSample.x,
@@ -59,7 +59,7 @@ export class NodePlay {
         )
         const unsubscribeKey = this.boardView.keyStream.subscribe(
             (keySample) => {
-                const e: KeySampledEvent = {
+                const e: UnindexedEvent = {
                     event_type: 'KeySampledEvent',
                     t: keySample.t,
                     key: keySample.key,
@@ -141,11 +141,10 @@ export class NodePlay {
         this.boardView.setBoardState(true, true);
 
         // Emit start event:
-        const eStart: NodeStartedEvent = {
+        const eStart: UnindexedEvent = {
             event_type: 'NodeStartedEvent',
             t: this.boardView.clock.now(),
             node_address: this.nodeAddress,
-            node: this.node,
         }
         this.eventArray.push(eStart)
 
@@ -158,7 +157,7 @@ export class NodePlay {
         const action = await this.deferredAction.promise;
 
         // Emit action event:
-        const eAction: ActionTakenEvent = {
+        const eAction: UnindexedEvent = {
             event_type: 'ActionTakenEvent',
             node_address: this.nodeAddress,
             action: action,
@@ -171,7 +170,7 @@ export class NodePlay {
         const tEnd = this.boardView.clock.now()
 
         // Emit end event:
-        const eEnd: NodeEndedEvent = {
+        const eEnd: UnindexedEvent = {
             event_type: 'NodeEndedEvent',
             t: tEnd,
             node_address: this.nodeAddress,
@@ -181,4 +180,3 @@ export class NodePlay {
         return action
     }
 }
-

--- a/nodekit-browser/src/node-play/index.ts
+++ b/nodekit-browser/src/node-play/index.ts
@@ -9,7 +9,7 @@ import type {Clock} from "../clock.ts";
 import {Deferred} from "../utils.ts";
 import type {NodeAddress} from "../types/values.ts";
 import type {EventArray} from "../event-array.ts";
-import type {UnindexedEvent} from "../types/events";
+import type {ActionTakenEvent, KeySampledEvent, NodeEndedEvent, NodeStartedEvent, PointerSampledEvent} from "../types/events";
 
 
 export class NodePlay {
@@ -47,7 +47,7 @@ export class NodePlay {
         // Have the input streams push to the event stream: todo despaghetti
         const unsubscribePointer = this.boardView.pointerStream.subscribe(
             (pointerSample) => {
-                const e: UnindexedEvent = {
+                const e: PointerSampledEvent = {
                     event_type: 'PointerSampledEvent',
                     t: pointerSample.t,
                     x: pointerSample.x,
@@ -59,7 +59,7 @@ export class NodePlay {
         )
         const unsubscribeKey = this.boardView.keyStream.subscribe(
             (keySample) => {
-                const e: UnindexedEvent = {
+                const e: KeySampledEvent = {
                     event_type: 'KeySampledEvent',
                     t: keySample.t,
                     key: keySample.key,
@@ -141,7 +141,7 @@ export class NodePlay {
         this.boardView.setBoardState(true, true);
 
         // Emit start event:
-        const eStart: UnindexedEvent = {
+        const eStart: NodeStartedEvent = {
             event_type: 'NodeStartedEvent',
             t: this.boardView.clock.now(),
             node_address: this.nodeAddress,
@@ -157,7 +157,7 @@ export class NodePlay {
         const action = await this.deferredAction.promise;
 
         // Emit action event:
-        const eAction: UnindexedEvent = {
+        const eAction: ActionTakenEvent = {
             event_type: 'ActionTakenEvent',
             node_address: this.nodeAddress,
             action: action,
@@ -170,7 +170,7 @@ export class NodePlay {
         const tEnd = this.boardView.clock.now()
 
         // Emit end event:
-        const eEnd: UnindexedEvent = {
+        const eEnd: NodeEndedEvent = {
             event_type: 'NodeEndedEvent',
             t: tEnd,
             node_address: this.nodeAddress,

--- a/nodekit-browser/src/types/events/index.ts
+++ b/nodekit-browser/src/types/events/index.ts
@@ -1,9 +1,9 @@
-import type {NodeId, PixelSize, PressableKey, PixelPoint, TimeElapsedMsec} from "../values.ts";
+import type {GraphAddress, NodeAddress, PixelSize, PressableKey, PixelPoint, TimeElapsedMsec} from "../values.ts";
 import type {Action} from "../actions.ts";
-import type {Node} from "../node.ts";
 
 export interface BaseEvent<T extends string> {
     event_type: T,
+    event_index: number,
     t: TimeElapsedMsec, // The time the Event was emitted, relative to the start of the Trace
 }
 
@@ -32,8 +32,7 @@ export interface BrowserContextSampledEvent extends BaseEvent<'BrowserContextSam
 
 // Graph events:
 interface BaseGraphEvent<T extends string> extends BaseEvent<T>{
-    graph_address: NodeId[]
-    annotation: string | null
+    graph_address: GraphAddress
 }
 
 export interface GraphStartedEvent extends BaseGraphEvent<'GraphStartedEvent'> {}
@@ -42,12 +41,10 @@ export interface GraphEndedEvent extends BaseGraphEvent<'GraphEndedEvent'> {}
 
 // Node events:
 interface BaseNodeEvent<T extends string> extends BaseEvent<T>{
-    node_address: NodeId[]
+    node_address: NodeAddress
 }
 
-export interface NodeStartedEvent extends BaseNodeEvent<'NodeStartedEvent'>{
-    node: Node
-}
+export interface NodeStartedEvent extends BaseNodeEvent<'NodeStartedEvent'>{}
 
 export interface ActionTakenEvent extends BaseNodeEvent<'ActionTakenEvent'>{
     action: Action
@@ -81,3 +78,9 @@ export type Event =
     | NodeEndedEvent
     | TraceStartedEvent
     | TraceEndedEvent
+
+export type UnindexedEvent = Event extends infer E
+    ? E extends Event
+        ? Omit<E, 'event_index'>
+        : never
+    : never

--- a/nodekit-browser/src/types/events/index.ts
+++ b/nodekit-browser/src/types/events/index.ts
@@ -3,7 +3,6 @@ import type {Action} from "../actions.ts";
 
 export interface BaseEvent<T extends string> {
     event_type: T,
-    event_index: number,
     t: TimeElapsedMsec, // The time the Event was emitted, relative to the start of the Trace
 }
 
@@ -17,7 +16,7 @@ export interface PageSuspendedEvent extends BaseEvent<'PageSuspendedEvent'>{}
 
 export interface PageResumedEvent extends BaseEvent<'PageResumedEvent'>{}
 
-interface RegionSizePx {
+export interface RegionSizePx {
     width_px: PixelSize,
     height_px: PixelSize
 }
@@ -78,9 +77,3 @@ export type Event =
     | NodeEndedEvent
     | TraceStartedEvent
     | TraceEndedEvent
-
-export type UnindexedEvent = Event extends infer E
-    ? E extends Event
-        ? Omit<E, 'event_index'>
-        : never
-    : never

--- a/nodekit-browser/src/types/node.ts
+++ b/nodekit-browser/src/types/node.ts
@@ -25,5 +25,6 @@ export interface Graph {
 
 export interface Trace {
     nodekit_version: string;
+    graph: Graph;
     events: Event[]
 }

--- a/nodekit-browser/src/types/values.ts
+++ b/nodekit-browser/src/types/values.ts
@@ -47,4 +47,5 @@ export type SHA256 = String & { __brand: 'SHA256' };
 // Identifiers
 export type NodeId = String & { __brand: 'NodeId' };
 export type NodeAddress = NodeId[]
+export type GraphAddress = NodeAddress
 export type RegisterId = String & { __brand: 'RegisterId' };

--- a/nodekit-browser/src/user-gates/browser-context.ts
+++ b/nodekit-browser/src/user-gates/browser-context.ts
@@ -2,7 +2,7 @@ import type {Clock} from "../clock.ts";
 import type {PixelSize} from "../types/values.ts";
 import type {BrowserContextSampledEvent} from "../types/events";
 
-export function sampleBrowserContext(clock: Clock): BrowserContextSampledEvent {
+export function sampleBrowserContext(clock: Clock): Omit<BrowserContextSampledEvent, 'event_index'> {
     return {
         event_type: 'BrowserContextSampledEvent',
         t: clock.now(),

--- a/nodekit-browser/src/user-gates/browser-context.ts
+++ b/nodekit-browser/src/user-gates/browser-context.ts
@@ -2,7 +2,7 @@ import type {Clock} from "../clock.ts";
 import type {PixelSize} from "../types/values.ts";
 import type {BrowserContextSampledEvent} from "../types/events";
 
-export function sampleBrowserContext(clock: Clock): Omit<BrowserContextSampledEvent, 'event_index'> {
+export function sampleBrowserContext(clock: Clock): BrowserContextSampledEvent {
     return {
         event_type: 'BrowserContextSampledEvent',
         t: clock.now(),

--- a/nodekit/_internal/ops/play/local_runner/main.py
+++ b/nodekit/_internal/ops/play/local_runner/main.py
@@ -306,7 +306,7 @@ def play(
                 break
             time.sleep(0.1)
 
-        return Trace(events=events)
+        return Trace(graph=graph, events=events)
     finally:
         # Shut down the server no matter how we exit
         runner.shutdown()

--- a/nodekit/_internal/ops/play/local_runner/site-template.j2
+++ b/nodekit/_internal/ops/play/local_runner/site-template.j2
@@ -12,18 +12,20 @@
     <script>
         const graph = {{ graph | tojson(indent=4) | indent(8, first=False) }};
         const eventSubmitUrl = "{{ submit_event_url }}";
+        let eventSubmitQueue = Promise.resolve();
 
-        async function sendEvent(ev) {
+        function sendEvent(ev) {
             console.log(ev)
-            try {
+            eventSubmitQueue = eventSubmitQueue.then(async () => {
                 await fetch(eventSubmitUrl, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify(ev),
                 });
-            } catch (err) {
+            }).catch((err) => {
                 console.error("Failed to send event", err);
-            }
+            });
+            return eventSubmitQueue;
         }
 
         window.onload = async () => {

--- a/nodekit/_internal/ops/simulate/simulate.py
+++ b/nodekit/_internal/ops/simulate/simulate.py
@@ -47,19 +47,31 @@ def simulate(
 
     time_elapsed_msec = 0
 
-    events: list[e.Event] = [e.TraceStartedEvent(t=time_elapsed_msec)]
+    events: list[e.Event] = []
+    events.append(
+        e.TraceStartedEvent(
+            event_index=_next_event_index(events),
+            t=time_elapsed_msec,
+        )
+    )
 
-    simulated_events, _, time_elapsed_msec = _simulate_core(
+    _, time_elapsed_msec = _simulate_core(
         graph=graph,
         agent=agent,
         address=[],
         time_elapsed_msec=time_elapsed_msec,
+        events=events,
     )
-    events.extend(simulated_events)
 
-    events.append(e.TraceEndedEvent(t=time_elapsed_msec))
+    events.append(
+        e.TraceEndedEvent(
+            event_index=_next_event_index(events),
+            t=time_elapsed_msec,
+        )
+    )
 
     return Trace(
+        graph=graph,
         events=events,
     )
 
@@ -76,7 +88,8 @@ def _simulate_core(
     agent: BaseAgent,
     address: list[str],
     time_elapsed_msec: int,
-) -> tuple[list[e.Event], dict[RegisterId, Value], int]:
+    events: list[e.Event],
+) -> tuple[dict[RegisterId, Value], int]:
     """
     Deterministically simulates a Graph using the provided Agent.
     Pointer and keyboard sample events are omitted; only Node start/action/end events
@@ -90,13 +103,13 @@ def _simulate_core(
         time_elapsed_msec += 1
         return time_elapsed_msec
 
-    events: list[e.Event] = [
+    events.append(
         e.GraphStartedEvent(
+            event_index=_next_event_index(events),
             t=_tick(),
             graph_address=address,
-            annotation=graph.annotation,
         )
-    ]
+    )
 
     current_node_id = graph.start
 
@@ -106,22 +119,22 @@ def _simulate_core(
 
         if isinstance(node_or_graph, Graph):
             child_graph = node_or_graph
-            child_events, child_registers, time_elapsed_msec = _simulate_core(
+            child_registers, time_elapsed_msec = _simulate_core(
                 graph=child_graph,
                 agent=agent,
                 address=current_address,
                 time_elapsed_msec=time_elapsed_msec,
+                events=events,
             )
-            events.extend(child_events)
             last_subgraph_registers = child_registers
             last_action = None
         elif isinstance(node_or_graph, Node):
             node = node_or_graph
             events.append(
                 e.NodeStartedEvent(
+                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
-                    node=node,
                 )
             )
 
@@ -133,6 +146,7 @@ def _simulate_core(
 
             events.append(
                 e.ActionTakenEvent(
+                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
                     action=action,
@@ -140,6 +154,7 @@ def _simulate_core(
             )
             events.append(
                 e.NodeEndedEvent(
+                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
                 )
@@ -173,13 +188,17 @@ def _simulate_core(
 
     events.append(
         e.GraphEndedEvent(
+            event_index=_next_event_index(events),
             t=_tick(),
             graph_address=address,
-            annotation=graph.annotation,
         )
     )
 
-    return events, registers, time_elapsed_msec
+    return registers, time_elapsed_msec
+
+
+def _next_event_index(events: list[e.Event]) -> int:
+    return len(events)
 
 
 def _eval_transition(

--- a/nodekit/_internal/ops/simulate/simulate.py
+++ b/nodekit/_internal/ops/simulate/simulate.py
@@ -50,7 +50,6 @@ def simulate(
     events: list[e.Event] = []
     events.append(
         e.TraceStartedEvent(
-            event_index=_next_event_index(events),
             t=time_elapsed_msec,
         )
     )
@@ -65,7 +64,6 @@ def simulate(
 
     events.append(
         e.TraceEndedEvent(
-            event_index=_next_event_index(events),
             t=time_elapsed_msec,
         )
     )
@@ -105,7 +103,6 @@ def _simulate_core(
 
     events.append(
         e.GraphStartedEvent(
-            event_index=_next_event_index(events),
             t=_tick(),
             graph_address=address,
         )
@@ -132,7 +129,6 @@ def _simulate_core(
             node = node_or_graph
             events.append(
                 e.NodeStartedEvent(
-                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
                 )
@@ -146,7 +142,6 @@ def _simulate_core(
 
             events.append(
                 e.ActionTakenEvent(
-                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
                     action=action,
@@ -154,7 +149,6 @@ def _simulate_core(
             )
             events.append(
                 e.NodeEndedEvent(
-                    event_index=_next_event_index(events),
                     t=_tick(),
                     node_address=current_address,
                 )
@@ -188,17 +182,12 @@ def _simulate_core(
 
     events.append(
         e.GraphEndedEvent(
-            event_index=_next_event_index(events),
             t=_tick(),
             graph_address=address,
         )
     )
 
     return registers, time_elapsed_msec
-
-
-def _next_event_index(events: list[e.Event]) -> int:
-    return len(events)
 
 
 def _eval_transition(

--- a/nodekit/_internal/types/events.py
+++ b/nodekit/_internal/types/events.py
@@ -36,10 +36,6 @@ class EventTypeEnum(str, enum.Enum):
 # %%
 class BaseEvent(pydantic.BaseModel):
     event_type: EventTypeEnum
-    event_index: int = pydantic.Field(
-        ge=0,
-        description="The zero-based index of this Event within its Trace.",
-    )
     t: TimeElapsedMsec = pydantic.Field(
         description="The number of elapsed milliseconds since TraceStartedEvent."
     )

--- a/nodekit/_internal/types/events.py
+++ b/nodekit/_internal/types/events.py
@@ -5,11 +5,11 @@ from typing import Literal, Annotated, Union
 import pydantic
 
 from nodekit._internal.types.actions import Action
-from nodekit._internal.types.node import Node
 from nodekit._internal.types.values import (
     TimeElapsedMsec,
     PixelPoint,
     NodeAddress,
+    GraphAddress,
 )
 
 
@@ -36,8 +36,12 @@ class EventTypeEnum(str, enum.Enum):
 # %%
 class BaseEvent(pydantic.BaseModel):
     event_type: EventTypeEnum
+    event_index: int = pydantic.Field(
+        ge=0,
+        description="The zero-based index of this Event within its Trace.",
+    )
     t: TimeElapsedMsec = pydantic.Field(
-        description="The number of elapsed milliseconds since StartedEvent."
+        description="The number of elapsed milliseconds since TraceStartedEvent."
     )
 
 
@@ -90,8 +94,7 @@ class BrowserContextSampledEvent(BaseEvent):
 
 # %% Graph events
 class BaseGraphEvent(BaseEvent):
-    graph_address: NodeAddress
-    annotation: str | None = None
+    graph_address: GraphAddress
 
 
 class GraphStartedEvent(BaseGraphEvent):
@@ -123,7 +126,6 @@ class BaseNodeEvent(BaseEvent):
 
 class NodeStartedEvent(BaseNodeEvent):
     event_type: Literal[EventTypeEnum.NodeStartedEvent] = EventTypeEnum.NodeStartedEvent
-    node: Node
 
 
 class ActionTakenEvent(BaseNodeEvent):

--- a/nodekit/_internal/types/trace.py
+++ b/nodekit/_internal/types/trace.py
@@ -17,13 +17,3 @@ class Trace(pydantic.BaseModel):
     @classmethod
     def validate_nodekit_version(cls, value: str) -> str:
         return validate_compatible_nodekit_version(value)
-
-    @pydantic.model_validator(mode="after")
-    def validate_event_indexes(self) -> "Trace":
-        for expected_index, event in enumerate(self.events):
-            if event.event_index != expected_index:
-                raise ValueError(
-                    "Trace events must have zero-based, contiguous event_index values "
-                    f"in list order. Expected {expected_index}, got {event.event_index}."
-                )
-        return self

--- a/nodekit/_internal/types/trace.py
+++ b/nodekit/_internal/types/trace.py
@@ -2,6 +2,7 @@ import pydantic
 
 from nodekit import VERSION
 from nodekit._internal.types.events import Event
+from nodekit._internal.types.graph import Graph
 from nodekit._internal.version import validate_compatible_nodekit_version
 
 
@@ -9,6 +10,7 @@ from nodekit._internal.version import validate_compatible_nodekit_version
 class Trace(pydantic.BaseModel):
     nodekit_version: str = pydantic.Field(default=VERSION, validate_default=True)
 
+    graph: Graph
     events: list[Event]
 
     @pydantic.field_validator("nodekit_version")
@@ -16,6 +18,12 @@ class Trace(pydantic.BaseModel):
     def validate_nodekit_version(cls, value: str) -> str:
         return validate_compatible_nodekit_version(value)
 
-    @pydantic.field_validator("events")
-    def order_events(cls, events: list[Event]) -> list[Event]:
-        return sorted(events, key=lambda e: e.t)
+    @pydantic.model_validator(mode="after")
+    def validate_event_indexes(self) -> "Trace":
+        for expected_index, event in enumerate(self.events):
+            if event.event_index != expected_index:
+                raise ValueError(
+                    "Trace events must have zero-based, contiguous event_index values "
+                    f"in list order. Expected {expected_index}, got {event.event_index}."
+                )
+        return self

--- a/nodekit/_internal/types/values.py
+++ b/nodekit/_internal/types/values.py
@@ -142,6 +142,8 @@ type NodeAddress = Annotated[
     ),
 ]
 
+type GraphAddress = NodeAddress
+
 type RegisterId = Annotated[str, pydantic.Field(description="An identifier for a Graph register.")]
 
 

--- a/nodekit/values.py
+++ b/nodekit/values.py
@@ -25,6 +25,7 @@ __all__ = [
     "NodeId",
     "RegisterId",
     "NodeAddress",
+    "GraphAddress",
 ]
 
 from nodekit._internal.types.values import (
@@ -52,4 +53,5 @@ from nodekit._internal.types.values import (
     NodeId,
     RegisterId,
     NodeAddress,
+    GraphAddress,
 )

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -32,10 +32,6 @@ def _event_type_names(trace: nk.Trace) -> list[str]:
     return [event.event_type.value for event in trace.events]
 
 
-def _event_indexes(trace: nk.Trace) -> list[int]:
-    return [event.event_index for event in trace.events]
-
-
 def test_simulate_register_update_and_branch() -> None:
     graph = nk.Graph(
         start="start",
@@ -137,7 +133,6 @@ def test_simulate_emits_root_graph_lifecycle_events() -> None:
 
     trace = nk.simulate(graph)
 
-    assert _event_indexes(trace) == list(range(len(trace.events)))
     assert _event_type_names(trace) == [
         "TraceStartedEvent",
         "GraphStartedEvent",

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -32,6 +32,10 @@ def _event_type_names(trace: nk.Trace) -> list[str]:
     return [event.event_type.value for event in trace.events]
 
 
+def _event_indexes(trace: nk.Trace) -> list[int]:
+    return [event.event_index for event in trace.events]
+
+
 def test_simulate_register_update_and_branch() -> None:
     graph = nk.Graph(
         start="start",
@@ -74,6 +78,7 @@ def test_simulate_register_update_and_branch() -> None:
 
     trace = nk.simulate(graph)
 
+    assert trace.graph == graph
     assert _node_addresses(trace) == [["start"], ["next"]]
 
 
@@ -132,6 +137,7 @@ def test_simulate_emits_root_graph_lifecycle_events() -> None:
 
     trace = nk.simulate(graph)
 
+    assert _event_indexes(trace) == list(range(len(trace.events)))
     assert _event_type_names(trace) == [
         "TraceStartedEvent",
         "GraphStartedEvent",
@@ -143,11 +149,10 @@ def test_simulate_emits_root_graph_lifecycle_events() -> None:
     ]
     assert isinstance(trace.events[1], nk.events.GraphStartedEvent)
     assert trace.events[1].graph_address == []
-    assert trace.events[1].annotation == "root graph"
     root_graph_end = trace.events[-2]
     assert isinstance(root_graph_end, nk.events.GraphEndedEvent)
     assert root_graph_end.graph_address == []
-    assert root_graph_end.annotation == "root graph"
+    assert trace.graph.annotation == "root graph"
 
 
 def test_simulate_child_register_branching() -> None:
@@ -239,14 +244,16 @@ def test_simulate_emits_nested_graph_lifecycle_events() -> None:
         if isinstance(event, (nk.events.GraphStartedEvent, nk.events.GraphEndedEvent))
     ]
 
-    assert [
-        (event.event_type.value, event.graph_address, event.annotation) for event in graph_events
-    ] == [
-        ("GraphStartedEvent", [], "root graph"),
-        ("GraphStartedEvent", ["trial"], "child graph"),
-        ("GraphEndedEvent", ["trial"], "child graph"),
-        ("GraphEndedEvent", [], "root graph"),
+    assert [(event.event_type.value, event.graph_address) for event in graph_events] == [
+        ("GraphStartedEvent", []),
+        ("GraphStartedEvent", ["trial"]),
+        ("GraphEndedEvent", ["trial"]),
+        ("GraphEndedEvent", []),
     ]
+    assert trace.graph.annotation == "root graph"
+    child_graph = trace.graph.nodes["trial"]
+    assert isinstance(child_graph, nk.Graph)
+    assert child_graph.annotation == "child graph"
 
     nested_node_index = _event_type_names(trace).index("NodeEndedEvent")
     nested_graph_end_index = next(

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -47,7 +47,7 @@ def test_accepts_older_compatible_nodekit_version():
     trace = nk.Trace(
         nodekit_version=older,
         graph=minimal_graph(),
-        events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+        events=[nk.events.TraceStartedEvent(t=0)],
     )
 
     assert trace.nodekit_version == older
@@ -64,7 +64,7 @@ def test_rejects_newer_nodekit_version():
         nk.Trace(
             nodekit_version=newer,
             graph=minimal_graph(),
-            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+            events=[nk.events.TraceStartedEvent(t=0)],
         )
 
 
@@ -76,7 +76,7 @@ def test_rejects_incompatible_major_nodekit_version():
         nk.Trace(
             nodekit_version="1.0.0",
             graph=minimal_graph(),
-            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+            events=[nk.events.TraceStartedEvent(t=0)],
         )
 
 
@@ -85,7 +85,7 @@ def test_rejects_invalid_nodekit_version_string():
         nk.Trace(
             nodekit_version="not-a-version",
             graph=minimal_graph(),
-            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+            events=[nk.events.TraceStartedEvent(t=0)],
         )
 
 
@@ -100,7 +100,7 @@ def test_accepts_older_prerelease_when_runtime_is_final(monkeypatch: pytest.Monk
     trace = nk.Trace(
         nodekit_version=older_prerelease,
         graph=minimal_graph(),
-        events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+        events=[nk.events.TraceStartedEvent(t=0)],
     )
 
     assert trace.nodekit_version == older_prerelease
@@ -123,7 +123,7 @@ def test_rejects_final_release_when_runtime_is_prerelease(monkeypatch: pytest.Mo
         nk.Trace(
             nodekit_version=final_release,
             graph=minimal_graph(),
-            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+            events=[nk.events.TraceStartedEvent(t=0)],
         )
 
 
@@ -144,7 +144,7 @@ def test_rejects_newer_prerelease_when_runtime_is_prerelease(monkeypatch: pytest
         nk.Trace(
             nodekit_version=newer_prerelease,
             graph=minimal_graph(),
-            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
+            events=[nk.events.TraceStartedEvent(t=0)],
         )
 
 
@@ -155,7 +155,6 @@ def test_requires_graph():
                 "events": [
                     {
                         "event_type": "TraceStartedEvent",
-                        "event_index": 0,
                         "t": 0,
                     }
                 ],
@@ -163,26 +162,12 @@ def test_requires_graph():
         )
 
 
-def test_rejects_non_contiguous_event_indexes():
-    with pytest.raises(
-        pydantic.ValidationError,
-        match="Expected 1, got 2",
-    ):
-        nk.Trace(
-            graph=minimal_graph(),
-            events=[
-                nk.events.TraceStartedEvent(event_index=0, t=0),
-                nk.events.TraceEndedEvent(event_index=2, t=1),
-            ],
-        )
-
-
 def test_preserves_event_order_instead_of_sorting_by_time():
     trace = nk.Trace(
         graph=minimal_graph(),
         events=[
-            nk.events.TraceStartedEvent(event_index=0, t=1),
-            nk.events.TraceEndedEvent(event_index=1, t=0),
+            nk.events.TraceStartedEvent(t=1),
+            nk.events.TraceEndedEvent(t=0),
         ],
     )
 
@@ -198,7 +183,6 @@ def test_graph_events_validate_and_roundtrip():
     started = event_adapter.validate_python(
         {
             "event_type": "GraphStartedEvent",
-            "event_index": 1,
             "t": 1,
             "graph_address": [],
         }
@@ -206,7 +190,6 @@ def test_graph_events_validate_and_roundtrip():
     ended = event_adapter.validate_python(
         {
             "event_type": "GraphEndedEvent",
-            "event_index": 2,
             "t": 2,
             "graph_address": ["trial"],
         }
@@ -218,10 +201,10 @@ def test_graph_events_validate_and_roundtrip():
     trace = nk.Trace(
         graph=minimal_graph(),
         events=[
-            nk.events.TraceStartedEvent(event_index=0, t=0),
+            nk.events.TraceStartedEvent(t=0),
             started,
             ended,
-            nk.events.TraceEndedEvent(event_index=3, t=3),
+            nk.events.TraceEndedEvent(t=3),
         ],
     )
 

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -30,11 +30,24 @@ def newer_prerelease_version() -> str:
     return f"{final_release_version()}.dev2"
 
 
+def minimal_graph() -> nk.Graph:
+    return nk.Graph(
+        start="start",
+        nodes={
+            "start": nk.Node(sensor=nk.sensors.WaitSensor(duration_msec=1)),
+        },
+        transitions={
+            "start": nk.transitions.End(),
+        },
+    )
+
+
 def test_accepts_older_compatible_nodekit_version():
     older = compatible_older_version()
     trace = nk.Trace(
         nodekit_version=older,
-        events=[nk.events.TraceStartedEvent(t=0)],
+        graph=minimal_graph(),
+        events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
     )
 
     assert trace.nodekit_version == older
@@ -50,7 +63,8 @@ def test_rejects_newer_nodekit_version():
     ):
         nk.Trace(
             nodekit_version=newer,
-            events=[nk.events.TraceStartedEvent(t=0)],
+            graph=minimal_graph(),
+            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
         )
 
 
@@ -61,7 +75,8 @@ def test_rejects_incompatible_major_nodekit_version():
     ):
         nk.Trace(
             nodekit_version="1.0.0",
-            events=[nk.events.TraceStartedEvent(t=0)],
+            graph=minimal_graph(),
+            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
         )
 
 
@@ -69,7 +84,8 @@ def test_rejects_invalid_nodekit_version_string():
     with pytest.raises(pydantic.ValidationError, match="Invalid NodeKit version: not-a-version"):
         nk.Trace(
             nodekit_version="not-a-version",
-            events=[nk.events.TraceStartedEvent(t=0)],
+            graph=minimal_graph(),
+            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
         )
 
 
@@ -83,7 +99,8 @@ def test_accepts_older_prerelease_when_runtime_is_final(monkeypatch: pytest.Monk
 
     trace = nk.Trace(
         nodekit_version=older_prerelease,
-        events=[nk.events.TraceStartedEvent(t=0)],
+        graph=minimal_graph(),
+        events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
     )
 
     assert trace.nodekit_version == older_prerelease
@@ -105,7 +122,8 @@ def test_rejects_final_release_when_runtime_is_prerelease(monkeypatch: pytest.Mo
     ):
         nk.Trace(
             nodekit_version=final_release,
-            events=[nk.events.TraceStartedEvent(t=0)],
+            graph=minimal_graph(),
+            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
         )
 
 
@@ -125,8 +143,53 @@ def test_rejects_newer_prerelease_when_runtime_is_prerelease(monkeypatch: pytest
     ):
         nk.Trace(
             nodekit_version=newer_prerelease,
-            events=[nk.events.TraceStartedEvent(t=0)],
+            graph=minimal_graph(),
+            events=[nk.events.TraceStartedEvent(event_index=0, t=0)],
         )
+
+
+def test_requires_graph():
+    with pytest.raises(pydantic.ValidationError, match="graph"):
+        nk.Trace.model_validate(
+            {
+                "events": [
+                    {
+                        "event_type": "TraceStartedEvent",
+                        "event_index": 0,
+                        "t": 0,
+                    }
+                ],
+            }
+        )
+
+
+def test_rejects_non_contiguous_event_indexes():
+    with pytest.raises(
+        pydantic.ValidationError,
+        match="Expected 1, got 2",
+    ):
+        nk.Trace(
+            graph=minimal_graph(),
+            events=[
+                nk.events.TraceStartedEvent(event_index=0, t=0),
+                nk.events.TraceEndedEvent(event_index=2, t=1),
+            ],
+        )
+
+
+def test_preserves_event_order_instead_of_sorting_by_time():
+    trace = nk.Trace(
+        graph=minimal_graph(),
+        events=[
+            nk.events.TraceStartedEvent(event_index=0, t=1),
+            nk.events.TraceEndedEvent(event_index=1, t=0),
+        ],
+    )
+
+    assert [event.event_type for event in trace.events] == [
+        nk.events.EventTypeEnum.TraceStartedEvent,
+        nk.events.EventTypeEnum.TraceEndedEvent,
+    ]
 
 
 def test_graph_events_validate_and_roundtrip():
@@ -135,17 +198,17 @@ def test_graph_events_validate_and_roundtrip():
     started = event_adapter.validate_python(
         {
             "event_type": "GraphStartedEvent",
+            "event_index": 1,
             "t": 1,
             "graph_address": [],
-            "annotation": "root graph",
         }
     )
     ended = event_adapter.validate_python(
         {
             "event_type": "GraphEndedEvent",
+            "event_index": 2,
             "t": 2,
             "graph_address": ["trial"],
-            "annotation": None,
         }
     )
 
@@ -153,11 +216,12 @@ def test_graph_events_validate_and_roundtrip():
     assert isinstance(ended, nk.events.GraphEndedEvent)
 
     trace = nk.Trace(
+        graph=minimal_graph(),
         events=[
-            nk.events.TraceStartedEvent(t=0),
+            nk.events.TraceStartedEvent(event_index=0, t=0),
             started,
             ended,
-            nk.events.TraceEndedEvent(t=3),
+            nk.events.TraceEndedEvent(event_index=3, t=3),
         ],
     )
 


### PR DESCRIPTION
## Summary

Refactors `Trace` into a self-describing execution record:

```text
Trace
├── graph: canonical declarative Graph
└── events: ordered facts about execution through that Graph
```

A saved Trace now contains the Graph that was run, and Events reference that Graph by address instead of duplicating structural payloads.

## Changes

- Added required `Trace.graph: Graph`.
- Removed timestamp-based sorting from Trace validation; `Trace.events` list order is now the canonical Event order.
- Added `GraphAddress = NodeAddress` as a semantic alias.
- Updated `GraphStartedEvent` / `GraphEndedEvent` to carry only `graph_address`; Graph annotations are resolved through `Trace.graph`.
- Removed the duplicated `node` payload from `NodeStartedEvent`; Nodes are resolved through `Trace.graph` and `node_address`.
- Updated Python `simulate` and local `play` to return `Trace(graph=..., events=...)`.
- Updated browser Trace/Event types and submitted Trace payloads to include the canonical Graph.
- Kept browser Event construction explicit: callsites construct typed Events and push them through `EventArray`.
- Serialized local preview per-Event HTTP submissions so server-side Event order matches browser emission order.
- Updated docs and tests for the self-describing Trace shape.

## Testing

- `make lint`
- `make check`
- `uv run pytest`
- `npm run build`
