### PR TITLE
annotations are now JsonValue

### DIFF
--- a/nodekit-browser/src/types/node.ts
+++ b/nodekit-browser/src/types/node.ts
@@ -10,7 +10,7 @@ export interface Node {
     sensor: Sensor;
     board_color: ColorHexString;
     hide_pointer: boolean
-    annotation: string | null
+    annotation: Value
 }
 
 export interface Graph {
@@ -20,7 +20,7 @@ export interface Graph {
     transitions: Readonly<Record<NodeId, Transition>>;
     start: NodeId;
     registers: Readonly<Record<RegisterId, Value>>
-    annotation: string | null
+    annotation: Value
 }
 
 export interface Trace {

--- a/nodekit/_internal/types/graph.py
+++ b/nodekit/_internal/types/graph.py
@@ -6,7 +6,7 @@ from nodekit import VERSION, Node
 from nodekit._internal.version import validate_compatible_nodekit_version
 from nodekit._internal.types import expressions as expressions
 from nodekit._internal.types.transitions import Transition, Go, IfThenElse, End
-from nodekit._internal.types.values import NodeId, RegisterId, LeafValue
+from nodekit._internal.types.values import NodeId, RegisterId, LeafValue, JsonValue
 
 
 # %%
@@ -29,7 +29,7 @@ class Graph(pydantic.BaseModel):
         description="The initial register values. ",
     )
 
-    annotation: str | None = pydantic.Field(
+    annotation: JsonValue = pydantic.Field(
         default=None,
         description="An optional, user-defined annotation for the Graph that may be useful for debugging or analysis purposes.",
     )

--- a/nodekit/_internal/types/node.py
+++ b/nodekit/_internal/types/node.py
@@ -4,7 +4,7 @@ import pydantic
 
 from nodekit._internal.types.cards import Card
 from nodekit._internal.types.sensors import Sensor
-from nodekit._internal.types.values import ColorHexString
+from nodekit._internal.types.values import ColorHexString, JsonValue
 
 
 # %%
@@ -29,7 +29,7 @@ class Node(pydantic.BaseModel):
         description="Whether to hide the mouse pointer during this Node.",
     )
 
-    annotation: str | None = pydantic.Field(
+    annotation: JsonValue = pydantic.Field(
         default=None,
         description="An optional, user-defined annotation for the Node that may be useful for debugging or analysis purposes.",
     )

--- a/nodekit/_internal/types/values.py
+++ b/nodekit/_internal/types/values.py
@@ -1,4 +1,5 @@
-from typing import Literal, Annotated
+import math
+from typing import Any, Literal, Annotated
 
 import pydantic
 
@@ -8,6 +9,36 @@ type List = list["Value"]
 type Dict = dict[str, "Value"]
 type LeafValue = bool | int | float | str
 type Value = LeafValue | List | Dict | None
+
+
+def _validate_json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("JSON numbers must be finite.")
+        return value
+
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item)
+        return value
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("JSON object keys must be strings.")
+            _validate_json_value(item)
+        return value
+
+    raise ValueError(f"Value must be valid JSON, got {type(value).__name__}.")
+
+
+type JsonValue = Annotated[
+    pydantic.JsonValue,
+    pydantic.BeforeValidator(_validate_json_value),
+]
 
 
 # %% Spatial

--- a/nodekit/values.py
+++ b/nodekit/values.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "Value",
+    "JsonValue",
     "List",
     "Dict",
     "LeafValue",
@@ -30,6 +31,7 @@ __all__ = [
 
 from nodekit._internal.types.values import (
     Value,
+    JsonValue,
     List,
     Dict,
     LeafValue,

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -206,6 +206,16 @@ def test_simulate_child_register_branching() -> None:
 
 
 def test_simulate_emits_nested_graph_lifecycle_events() -> None:
+    child_annotation = {
+        "kind": "child",
+        "trial": 1,
+        "tags": ["nested", "practice"],
+    }
+    root_annotation = {
+        "kind": "root",
+        "version": 2,
+        "metadata": {"counterbalanced": True},
+    }
     child = nk.Graph(
         start="inner",
         nodes={
@@ -217,7 +227,7 @@ def test_simulate_emits_nested_graph_lifecycle_events() -> None:
         transitions={
             "inner": nk.transitions.End(),
         },
-        annotation="child graph",
+        annotation=child_annotation,
     )
 
     graph = nk.Graph(
@@ -228,7 +238,7 @@ def test_simulate_emits_nested_graph_lifecycle_events() -> None:
         transitions={
             "trial": nk.transitions.End(),
         },
-        annotation="root graph",
+        annotation=root_annotation,
     )
 
     trace = nk.simulate(graph)
@@ -245,10 +255,10 @@ def test_simulate_emits_nested_graph_lifecycle_events() -> None:
         ("GraphEndedEvent", ["trial"]),
         ("GraphEndedEvent", []),
     ]
-    assert trace.graph.annotation == "root graph"
+    assert trace.graph.annotation == root_annotation
     child_graph = trace.graph.nodes["trial"]
     assert isinstance(child_graph, nk.Graph)
-    assert child_graph.annotation == "child graph"
+    assert child_graph.annotation == child_annotation
 
     nested_node_index = _event_type_names(trace).index("NodeEndedEvent")
     nested_graph_end_index = next(


### PR DESCRIPTION
## Summary
- Allow `Node.annotation` and `Graph.annotation` to hold arbitrary strict JSON values instead of only strings.
- Add a reusable exported `JsonValue` type for Python models.
- Update browser Graph/Node types so annotations use the existing JSON-like `Value` type.

## Details
- Structured annotations now support strings, numbers, booleans, null, arrays, and objects with string keys.
- Validation rejects Python-only/non-JSON values, including non-finite floats, non-string object keys, tuples, datetimes, paths, bytes, and arbitrary objects.
- Annotation behavior remains passive: annotations are serialized, round-tripped, and preserved in traces, but are not interpreted by execution logic.

## Tests
- Added model validation coverage for valid and invalid annotation values.
- Added JSON round-trip coverage for structured Graph annotations.
- Updated simulation coverage to verify nested structured Graph annotations survive tracing.

## Verification
- `uv run pytest tests/test_annotations.py tests/test_simulate.py tests/test_trace.py`
- `make check`